### PR TITLE
Prevent infinite loop for remote circular dependencies

### DIFF
--- a/src/NodeModuleFederation/index.js
+++ b/src/NodeModuleFederation/index.js
@@ -53,8 +53,14 @@ function buildRemotes(mfConf) {
   return Object.entries(mfConf.remotes).reduce((acc, [name, config]) => {
     acc[name] = {
       external: `external (function() {
-        ${builtinsTemplate}
-        return rpcPerform("${config}").then(rpcProcess)
+        if (!globalThis._MFRemotes) {
+          globalThis._MFRemotes = {};
+        }
+        if (!globalThis._MFRemotes["${name}"]) {
+          ${builtinsTemplate}
+          globalThis._MFRemotes["${name}"] = rpcPerform("${config}").then(rpcProcess)
+        }
+        return globalThis._MFRemotes["${name}"];
       }())`,
     };
     return acc;


### PR DESCRIPTION
This fixes an infinite loop when remotes have circular dependencies. Without this, it appears that a new remote is defined and initialized even if that remote has already been created.

This is not very polished, but putting it out there in case it can help someone else.