### PR TITLE
Add Next.js support when used as remote

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,7 +48,7 @@ Full example is here https://github.com/telenko/node-mf-example/blob/master/remo
 
 ### 2) On NodeJS application:
 
-  2.1) Install library 
+  2.1) Install library
     ```
     npm i --save-dev @telenko/node-mf
     ```
@@ -75,6 +75,44 @@ Full example is here https://github.com/telenko/node-mf-example/blob/master/remo
         ...otherWebpackOptions
     };
   ```
+
+### Usage with Next.js
+
+As Next.js use an internal version of webpack, it's mandatory to use their version. To do so, use the second argument of the 2 plugins to send the "context" of the [webpack options](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config).
+
+```js
+// next.config.js
+module.exports = {
+    webpack: (config, options) => {
+        config.plugins.push(
+            new NodeAsyncHttpRuntime({}, options)
+        );
+        return config
+    },
+}
+```
+```js
+// next.config.js
+module.exports = {
+    webpack: (config, options) => {
+        config.plugins.push(
+            new NodeModuleFederation({
+                remotes: {
+                    someLib: "someLib@http://some-url/remoteEntry.node.js"
+                },
+                shared: {
+                    lodash: {
+                        eager: true,
+                        singleton: true,
+                        requiredVersion: "1.1.2"
+                    }
+                }
+            }, options)
+        );
+        return config
+    },
+}
+```
 
 Full example of setuping NextJS with SSR here https://github.com/telenko/node-mf-example/blob/master/host/next.config.js
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telenko/node-mf",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Module Federation plugin support for NodeJS",
   "main": "src/index.js",
   "scripts": {

--- a/src/NodeAsyncHttpRuntime/CommonJsChunkLoadingPlugin.js
+++ b/src/NodeAsyncHttpRuntime/CommonJsChunkLoadingPlugin.js
@@ -3,87 +3,86 @@ const StartupChunkDependenciesPlugin = require("webpack/lib/runtime/StartupChunk
 const ChunkLoadingRuntimeModule = require("./LoadFileChunkLoadingRuntimeModule");
 
 class CommonJsChunkLoadingPlugin {
-	constructor(options) {
-		options = options || {};
-		this._asyncChunkLoading = true;
-        this.baseURI = options.baseURI;
-	}
+  constructor(options, context) {
+    this.options = options || {};
+    this._asyncChunkLoading = this.options.asyncChunkLoading;
+    this.context = context || {};
+  }
 
-	/**
-	 * Apply the plugin
-	 * @param {Compiler} compiler the compiler instance
-	 * @returns {void}
-	 */
-	apply(compiler) {
-		const chunkLoadingValue = this._asyncChunkLoading
-			? "async-node"
-			: "require";
-		new StartupChunkDependenciesPlugin({
-			chunkLoading: chunkLoadingValue,
-			asyncChunkLoading: this._asyncChunkLoading
-		}).apply(compiler);
-		compiler.hooks.thisCompilation.tap(
-			"CommonJsChunkLoadingPlugin",
-			compilation => {
-				const isEnabledForChunk = chunk => {
-					return true;
-				};
-				const onceForChunkSet = new WeakSet();
-				const handler = (chunk, set) => {
-					if (onceForChunkSet.has(chunk)) return;
-					onceForChunkSet.add(chunk);
-					if (!isEnabledForChunk(chunk)) return;
-					set.add(RuntimeGlobals.moduleFactoriesAddOnly);
-					set.add(RuntimeGlobals.hasOwnProperty);
-					compilation.addRuntimeModule(
-						chunk,
-						new ChunkLoadingRuntimeModule(set, this.baseURI)
-					);
-				};
+  /**
+   * Apply the plugin
+   * @param {Compiler} compiler the compiler instance
+   * @returns {void}
+   */
+  apply(compiler) {
+    const chunkLoadingValue = this._asyncChunkLoading
+      ? "async-node"
+      : "require";
+    new StartupChunkDependenciesPlugin({
+      chunkLoading: chunkLoadingValue,
+      asyncChunkLoading: this._asyncChunkLoading,
+    }).apply(compiler);
+    compiler.hooks.thisCompilation.tap(
+      "CommonJsChunkLoadingPlugin",
+      (compilation) => {
+        // Always enabled
+        const isEnabledForChunk = () => true;
+        const onceForChunkSet = new WeakSet();
+        const handler = (chunk, set) => {
+          if (onceForChunkSet.has(chunk)) return;
+          onceForChunkSet.add(chunk);
+          if (!isEnabledForChunk(chunk)) return;
+          set.add(RuntimeGlobals.moduleFactoriesAddOnly);
+          set.add(RuntimeGlobals.hasOwnProperty);
+          compilation.addRuntimeModule(
+            chunk,
+            new ChunkLoadingRuntimeModule(set, this.options, this.context)
+          );
+        };
 
-				compilation.hooks.runtimeRequirementInTree
-					.for(RuntimeGlobals.ensureChunkHandlers)
-					.tap("CommonJsChunkLoadingPlugin", handler);
-				compilation.hooks.runtimeRequirementInTree
-					.for(RuntimeGlobals.hmrDownloadUpdateHandlers)
-					.tap("CommonJsChunkLoadingPlugin", handler);
-				compilation.hooks.runtimeRequirementInTree
-					.for(RuntimeGlobals.hmrDownloadManifest)
-					.tap("CommonJsChunkLoadingPlugin", handler);
-				compilation.hooks.runtimeRequirementInTree
-					.for(RuntimeGlobals.baseURI)
-					.tap("CommonJsChunkLoadingPlugin", handler);
-				compilation.hooks.runtimeRequirementInTree
-					.for(RuntimeGlobals.externalInstallChunk)
-					.tap("CommonJsChunkLoadingPlugin", handler);
-				compilation.hooks.runtimeRequirementInTree
-					.for(RuntimeGlobals.onChunksLoaded)
-					.tap("CommonJsChunkLoadingPlugin", handler);
+        compilation.hooks.runtimeRequirementInTree
+          .for(RuntimeGlobals.ensureChunkHandlers)
+          .tap("CommonJsChunkLoadingPlugin", handler);
+        compilation.hooks.runtimeRequirementInTree
+          .for(RuntimeGlobals.hmrDownloadUpdateHandlers)
+          .tap("CommonJsChunkLoadingPlugin", handler);
+        compilation.hooks.runtimeRequirementInTree
+          .for(RuntimeGlobals.hmrDownloadManifest)
+          .tap("CommonJsChunkLoadingPlugin", handler);
+        compilation.hooks.runtimeRequirementInTree
+          .for(RuntimeGlobals.baseURI)
+          .tap("CommonJsChunkLoadingPlugin", handler);
+        compilation.hooks.runtimeRequirementInTree
+          .for(RuntimeGlobals.externalInstallChunk)
+          .tap("CommonJsChunkLoadingPlugin", handler);
+        compilation.hooks.runtimeRequirementInTree
+          .for(RuntimeGlobals.onChunksLoaded)
+          .tap("CommonJsChunkLoadingPlugin", handler);
 
-				compilation.hooks.runtimeRequirementInTree
-					.for(RuntimeGlobals.ensureChunkHandlers)
-					.tap("CommonJsChunkLoadingPlugin", (chunk, set) => {
-						if (!isEnabledForChunk(chunk)) return;
-						set.add(RuntimeGlobals.getChunkScriptFilename);
-					});
-				compilation.hooks.runtimeRequirementInTree
-					.for(RuntimeGlobals.hmrDownloadUpdateHandlers)
-					.tap("CommonJsChunkLoadingPlugin", (chunk, set) => {
-						if (!isEnabledForChunk(chunk)) return;
-						set.add(RuntimeGlobals.getChunkUpdateScriptFilename);
-						set.add(RuntimeGlobals.moduleCache);
-						set.add(RuntimeGlobals.hmrModuleData);
-						set.add(RuntimeGlobals.moduleFactoriesAddOnly);
-					});
-				compilation.hooks.runtimeRequirementInTree
-					.for(RuntimeGlobals.hmrDownloadManifest)
-					.tap("CommonJsChunkLoadingPlugin", (chunk, set) => {
-						if (!isEnabledForChunk(chunk)) return;
-						set.add(RuntimeGlobals.getUpdateManifestFilename);
-					});
-			}
-		);
-	}
+        compilation.hooks.runtimeRequirementInTree
+          .for(RuntimeGlobals.ensureChunkHandlers)
+          .tap("CommonJsChunkLoadingPlugin", (chunk, set) => {
+            if (!isEnabledForChunk(chunk)) return;
+            set.add(RuntimeGlobals.getChunkScriptFilename);
+          });
+        compilation.hooks.runtimeRequirementInTree
+          .for(RuntimeGlobals.hmrDownloadUpdateHandlers)
+          .tap("CommonJsChunkLoadingPlugin", (chunk, set) => {
+            if (!isEnabledForChunk(chunk)) return;
+            set.add(RuntimeGlobals.getChunkUpdateScriptFilename);
+            set.add(RuntimeGlobals.moduleCache);
+            set.add(RuntimeGlobals.hmrModuleData);
+            set.add(RuntimeGlobals.moduleFactoriesAddOnly);
+          });
+        compilation.hooks.runtimeRequirementInTree
+          .for(RuntimeGlobals.hmrDownloadManifest)
+          .tap("CommonJsChunkLoadingPlugin", (chunk, set) => {
+            if (!isEnabledForChunk(chunk)) return;
+            set.add(RuntimeGlobals.getUpdateManifestFilename);
+          });
+      }
+    );
+  }
 }
 
 module.exports = CommonJsChunkLoadingPlugin;

--- a/src/NodeAsyncHttpRuntime/index.js
+++ b/src/NodeAsyncHttpRuntime/index.js
@@ -1,21 +1,42 @@
-const NodeEnvironmentPlugin = require("webpack/lib/node/NodeEnvironmentPlugin");
-const NodeTargetPlugin = require("webpack/lib/node/NodeTargetPlugin");
 const CommonJsChunkLoadingPlugin = require("./CommonJsChunkLoadingPlugin");
-const CommonJsChunkFormatPlugin = require("webpack/lib/javascript/CommonJsChunkFormatPlugin");
 
 class NodeAsyncHttpRuntime {
-  constructor(options) {
-    options = options || {};
+  constructor(options, context) {
+    this.options = options || {};
+    this.context = context || {};
   }
+
   apply(compiler) {
     if (compiler.options.target) {
-      console.warn(`target should be set to false while using NodeAsyncHttpRuntime plugin, actual target: ${compiler.options.target}`);
+      console.warn(
+        `target should be set to false while using NodeAsyncHttpRuntime plugin, actual target: ${compiler.options.target}`
+      );
     }
-    compiler.options.output.chunkFormat = 'commonjs';
-    new CommonJsChunkFormatPlugin().apply(compiler);
-    new NodeEnvironmentPlugin({ infrastructureLogging: compiler.options.infrastructureLogging }).apply(compiler);
-    new NodeTargetPlugin().apply(compiler);
-    new CommonJsChunkLoadingPlugin({ baseURI: compiler.options.output.publicPath }).apply(compiler);
+
+    // When used with Next.js, context is needed to use Next.js webpack
+    const { webpack } = this.context;
+
+    // This will enable CommonJsChunkFormatPlugin
+    compiler.options.output.chunkFormat = "commonjs";
+    // This will force async chunk loading
+    compiler.options.output.chunkLoading = "async-node";
+    // Disable default config
+    compiler.options.output.enabledChunkLoadingTypes = false;
+
+    new (webpack?.node.NodeEnvironmentPlugin ||
+      require("webpack/lib/node/NodeEnvironmentPlugin"))({
+      infrastructureLogging: compiler.options.infrastructureLogging,
+    }).apply(compiler);
+    new (webpack?.node.NodeTargetPlugin ||
+      require("webpack/lib/node/NodeTargetPlugin"))().apply(compiler);
+    new CommonJsChunkLoadingPlugin(
+      {
+        asyncChunkLoading: true,
+        baseURI: compiler.options.output.publicPath,
+        promiseBaseURI: this.options.promiseBaseURI,
+      },
+      this.context
+    ).apply(compiler);
   }
 }
 


### PR DESCRIPTION
Only SSR is supported, client-side hydration need to be handled. 
As it would require a large amount of code and as this package is named node-mf, I think it's not an issue. We can discuss about it if you want.

I also added a simple feature: baseURI can be modified with a Promise by using the promiseBaseURI option in NodeAsyncHttpRuntime plugin.

Note: I let Prettier format the files but if it's an issue for you, I can revert the changes.