### PR TITLE
Promise uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telenko/node-mf",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Module Federation plugin support for NodeJS",
   "main": "src/index.js",
   "scripts": {

--- a/src/NodeAsyncHttpRuntime/LoadFileChunkLoadingRuntimeModule.js
+++ b/src/NodeAsyncHttpRuntime/LoadFileChunkLoadingRuntimeModule.js
@@ -26,7 +26,7 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
    */
   generate() {
     const { chunkGraph, chunk } = this;
-    const { baseURI, promiseBaseURI } = this.options;
+    const { baseURI, getBaseUri } = this.options;
     const { webpack } = this.context;
     const { runtimeTemplate } = this.compilation;
     const fn = RuntimeGlobals.ensureChunkHandlers;
@@ -156,8 +156,8 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
                           }(chunkId));`,
                           rpcLoadTemplate,
                           `rpcLoad(${
-                            promiseBaseURI
-                              ? `await ${promiseBaseURI}`
+                            getBaseUri
+                              ? `await ${getBaseUri(baseURI)}`
                               : `"${baseURI}"`
                           }, ${
                             RuntimeGlobals.getChunkScriptFilename

--- a/src/NodeAsyncHttpRuntime/index.js
+++ b/src/NodeAsyncHttpRuntime/index.js
@@ -33,7 +33,7 @@ class NodeAsyncHttpRuntime {
       {
         asyncChunkLoading: true,
         baseURI: compiler.options.output.publicPath,
-        promiseBaseURI: this.options.promiseBaseURI,
+        getBaseUri: this.options.getBaseUri,
       },
       this.context
     ).apply(compiler);


### PR DESCRIPTION
Hello, it's me again. :slightly_smiling_face: 
Here is another MR to add runtime URIs for baseUri and remoteUri.
It's useful when assets are hosted on a CDN or when the build is run on multiple test environments.

I have tested it with the Next.js and regular webpack builds.

I added documentation and bumped the package.json file.